### PR TITLE
Updated StatSummaryType to include the Arsr and darkstar types

### DIFF
--- a/cassiopeia/type/core/common.py
+++ b/cassiopeia/type/core/common.py
@@ -437,6 +437,8 @@ class StatSummaryType(enum.Enum):
     ranked_premade_threes = "RankedPremade3x3"  # Not listed on game constants documentation page
     ranked_premade_fives = "RankedPremade5x5"   # Not listed on game constants documentation page
     assassinate = "Assassinate"
+    Arsr = "Arsr" # All random summoner's rift
+    Darkstar = "Darkstar"
 
 
 class Ascended(enum.Enum):


### PR DESCRIPTION
these game types were missing from the StatSummaryType list throwing errors when pulling summoner data.